### PR TITLE
Riyoukiyaku

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,11 +12,16 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
-    if @user.save
-      auto_login(@user)
-      redirect_to posts_path, notice: "ユーザーが作成されました"
+    if @user.terms_accepted?
+      if @user.save
+        auto_login(@user)
+        redirect_to posts_path, notice: "ユーザーが作成されました"
+      else
+        flash.now[:alert] = "パスワードは8文字で作成してください"
+        render :new, status: :unprocessable_entity
+      end
     else
-      flash.now[:alert] = "パスワードは8文字で作成してください"
+      flash.now[:alert] = "利用規約に同意する必要があります"
       render :new, status: :unprocessable_entity
     end
   end
@@ -24,6 +29,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:username, :email, :password, :password_confirmation)
+    params.require(:user).permit(:username, :email, :password, :password_confirmation, :terms_accepted)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
 	validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 	validates :username, presence: true, length: { maximum: 10 }
 	validates :email, presence: true, uniqueness: true
+	validates :terms_accepted, acceptance: { accept: true}
 end

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,4 +1,6 @@
 <header>
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+
 	<div class="bg-blue-400">
 		<!-- 文字の大きさと色 -->
 		<h1 class="inline-block text-5xl text-white">Empatia</h1>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -5,6 +5,13 @@
       <div class="flex md:text-base gap-2 md:gap-10 justify-around md:justify-center text-xl text-white">
         <%= link_to 'Terms of Use', terms_path %>
         <%= link_to 'Privacy Policy', privacy_policy_path %>
+
+        <a href="https://x.com/zhon3112" target="_blank">
+          <i class="fa-brands fa-twitter"></i>
+        </a>
+        <a href="https://github.com/zhon3112" target="_blank">
+          <i class="fa-brands fa-github"></i>
+        </a>
       </div>
 		</div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,6 @@
 <header>
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+
 	<div class="bg-blue-400">
 		<!-- 文字の大きさと色 -->
 		<h1 class="inline-block text-5xl text-white">Empatia</h1>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -22,11 +22,13 @@
 		<%= f.password_field :password_confirmation, class: "form-control" %>
 	</div>
 
+		<div>
+		<%= link_to '利用規約はこちらから', terms_path, target: '_blank' %>
+	</div>
+
 	<div class="field">
-		<%= f.label :terms_accepted do %>
-			<%= f.check_box :terms_accepted %>
-			利用規約に同意します
-		<% end %>
+		<%= f.check_box :terms_accepted, {}, true, false %>
+		<%= f.label :terms_accepted, '利用規約に同意します' %>
 	</div>
 
 	<%= f.submit "登録", class: "btn btn-primary" %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -22,10 +22,12 @@
 		<%= f.password_field :password_confirmation, class: "form-control" %>
 	</div>
 
+	<div class="field">
+		<%= f.label :terms_accepted do %>
+			<%= f.check_box :terms_accepted %>
+			利用規約に同意します
+		<% end %>
+	</div>
+
 	<%= f.submit "登録", class: "btn btn-primary" %>
 <% end %>
-
-	<% if current_user %>
-		<%= link_to '登録', posts_path(current_user.id) %>
-	<% end %>
-

--- a/db/migrate/20250118013309_add_terms_accepted_to_users.rb
+++ b/db/migrate/20250118013309_add_terms_accepted_to_users.rb
@@ -1,0 +1,5 @@
+class AddTermsAcceptedToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :terms_accepted, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_15_103159) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_18_013309) do
   create_table "posts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "content", limit: 140, null: false
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_15_103159) do
     t.string "salt"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "terms_accepted"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
## 作業内容
- ユーザー登録時に利用規約同意のチェックボックスを配置。
- 利用規約は別のタブを開いて表示。
- 同意なしでのユーザー登録は不可。
- 同意なしで登録しようとするとフラッシュメッセージが表示
- フッターにTwitterとGitHubを配置。
- 全ての動作確認済み