### PR TITLE
‘Google認証3’

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -82,4 +82,6 @@ gem 'meta-tags'
 
 gem 'jquery-rails'
 
+gem 'dotenv-rails'
+
 gem 'config'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,10 @@ GEM
       reline (>= 0.3.8)
     debug_inspector (1.2.0)
     deep_merge (1.2.2)
+    dotenv (3.1.7)
+    dotenv-rails (3.1.7)
+      dotenv (= 3.1.7)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.0)
     faraday (2.10.1)
@@ -324,6 +328,7 @@ DEPENDENCIES
   config
   cssbundling-rails
   debug
+  dotenv-rails
   jbuilder
   jquery-rails
   jsbundling-rails


### PR DESCRIPTION
## Google認証
 - [x] ENVに変更したら開発環境でも使用できなくなったため、別の方法を調べて.envを使用した。

## 参考記事
[【豆知識】Google認証APIキーを含む秘匿情報ENVコードで管理。+credentialとの違い](https://qiita.com/wa-chan222/items/9ae3c395591685e79361)
[【Rails】 初心者向け！gem 'dotenv-rails'の使い方](https://qiita.com/__Wata16__/items/d2d3aa21623f8c026d5d)