### PR TITLE
‘ユーザー登録とログインページ’

### DIFF
--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,27 +1,36 @@
-<h1 class="text-black">ログインページ</h1>
-<%= form_with url: login_path do |f| %>
-  <div>
-    <%= f.label :email %>
-    <%= f.email_field :email, class: "form-control" %>
-  </div>
+<div class="relative w-full min-h-screen flex flex-col justify-center items-center py-24 bg-cover bg-center">
+  <h1 class="text-2xl font-bold text-sans text-white/50 mb-8">ログインページ</h1>
 
-  <div>
-    <%= f.label :password %>
-    <%= f.password_field :password, class: "form-control" %>
-  </div>
+  <%= form_with url: login_path, class: "w-80 md:w-96 bg-white/10 p-6 rounded-xl shadow-lg backdrop-blur-md" do |f| %>
+    <div class="mb-4 md:mb-6">
+      <%= f.label :email, class: "block text-serif text-white/70 mb-2" %>
+      <%= f.email_field :email, class: "w-full p-3 rounded-lg bg-white/20 text-white focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
 
-  <div>
-    <%= check_box_tag :remember_me, params[:remember_me], true %>
-    <%= f.label :remember_me, '次回から自動でログインしますか？' %>
-  </div>
+    <div class="mb-4 md:mb-6">
+      <%= f.label :password, class: "block text-serif text-white/70 mb-2" %>
+      <%= f.password_field :password, class: "w-full p-3 rounded-lg bg-white/20 text-white focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
 
-  <div>
-    <%= f.submit 'Login', class: "btn btn-primary" %>
-  </div>
+    <div class="mb-4 md:mb-6 flex items-center">
+      <%= check_box_tag :remember_me, params[:remember_me], true, class: "mr-2" %>
+      <%= f.label :remember_me, '次回から自動でログインしますか？', class: "text-serif text-white/70" %>
+    </div>
 
-  <div>
-  <%= link_to auth_at_provider_path(provider: :google) do %>
-    <%= image_tag "google_sign_in.png" %>
+    <div class="mb-6">
+      <%= f.submit 'ログイン', class: "w-full py-3 bg-blue-500 text-serif text-white rounded-lg hover:bg-blue-600 transition duration-300" %>
+    </div>
+
+    <div class="flex items-center w-full my-4">
+      <div class="flex-grow border-t border-white/50"></div>
+      <span class="mx-4 text-serif text-white/50">または</span>
+      <div class="flex-grow border-t border-white/50"></div>
+    </div>
+
+    <div class="flex justify-center">
+      <%= link_to auth_at_provider_path(provider: :google) do %>
+        <%= image_tag "google_sign_in.png", class: "w-48" %>
+      <% end %>
+    </div>
   <% end %>
-  </div>
-<% end %>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,41 +1,50 @@
-<h1 class="text-black">新規登録</h1>
+<div class="relative w-full min-h-screen flex flex-col justify-center items-center py-24 bg-cover bg-center">
+  <h1 class="text-2xl font-bold text-sans text-white/50 mb-8">ユーザー登録</h1>
 
-<%= form_with(model: @user, local: true) do |f| %>
-	<div>
-		<%= f.label :username, class: "form-label" %>
-		<%= f.text_field :username, class: "form-control" %>
-	</div>
+  <%= form_with(model: @user, local: true, class: "w-80 md:w-96 bg-white/10 p-6 rounded-xl shadow-lg backdrop-blur-md") do |f| %>
+    <div class="mb-4 md:mb-6">
+      <%= f.label :username, class: "block text-serif text-white/70 mb-2" %>
+      <%= f.text_field :username, class: "w-full p-3 rounded-lg bg-white/20 text-white focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
 
-	<div>
-		<%= f.label :email, class: "form-label" %>
-		<%= f.email_field :email, class: "form-control" %>
-	</div>
+    <div class="mb-4 md:mb-6">
+      <%= f.label :email, class: "block text-serif text-white/70 mb-2" %>
+      <%= f.email_field :email, class: "w-full p-3 rounded-lg bg-white/20 text-white focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
 
-	<div>
-	<p>パスワードは8文字以上で作成してください</p>
-		<%= f.label :password, class: "form-label" %>
-		<%= f.password_field :password, class: "form-control" %>
-	</div>
+    <div class="mb-4 md:mb-6">
+      <%= f.label :password, class: "block text-serif text-white/70 mb-2" %>
+      <%= f.password_field :password, class: "w-full p-3 rounded-lg bg-white/20 text-white focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder:'パスワードは8文字以上で作成してください' %>
+    </div>
 
-	<div>
-		<%= f.label :password_confirmation, class: "form-label" %>
-		<%= f.password_field :password_confirmation, class: "form-control" %>
-	</div>
+    <div class="mb-4 md:mb-6">
+      <%= f.label :password_confirmation, class: "block text-serif text-white/70 mb-2" %>
+      <%= f.password_field :password_confirmation, class: "w-full p-3 rounded-lg bg-white/20 text-white focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    </div>
 
-	<div>
-		<%= link_to '利用規約はこちらから', terms_path, target: '_blank' %>
-	</div>
+    <div class="mb-4 md:mb-6">
+      <%= link_to '利用規約はこちらから', terms_path, target: '_blank', class: "text-serif text-blue-300 hover:text-blue-400" %>
+    </div>
 
-	<div class="field">
-		<%= f.check_box :terms_accepted, {}, true, false %>
-		<%= f.label :terms_accepted, '利用規約に同意します' %>
-	</div>
+    <div class="mb-4 md:mb-6 flex items-center">
+      <%= f.check_box :terms_accepted, {}, true, false %>
+      <%= f.label :terms_accepted, '利用規約に同意します', class: "text-serif text-white/70 mr-2" %>
+    </div>
 
-	<%= f.submit "登録", class: "btn btn-primary" %>
+    <div class="mb-6">
+      <%= f.submit "登録", class: "w-full py-3 bg-blue-500 text-serif text-white rounded-lg hover:bg-blue-600 transition duration-300" %>
+    </div>
 
-	<div>
-  <%= link_to auth_at_provider_path(provider: :google) do %>
-    <%= image_tag "google_sign_up.png" %>
+    <div class="flex items-center w-full my-4">
+      <div class="flex-grow border-t border-white/50"></div>
+      <span class="mx-4 text-serif text-white/50">または</span>
+      <div class="flex-grow border-t border-white/50"></div>
+    </div>
+
+    <div class="flex justify-center">
+      <%= link_to auth_at_provider_path(provider: :google) do %>
+        <%= image_tag "google_sign_up.png", class: "w-48" %>
+      <% end %>
+    </div>
   <% end %>
-  </div>
-<% end %>
+</div>


### PR DESCRIPTION
## ユーザー登録とログインページ
- [x] フォーム・フォームラベル・ボタンの位置を中央に配置
- [x] Google認証がわかりやすいようにまたはの文字で区切る